### PR TITLE
Add a new `--license-allows-edit` parameter to open protected font files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The font weight will be inherited from the original file; the font name will be 
 
 `ligatures.py` supports some additional command line options to (e.g.) change which font ligatures are copied from or enable copying of individual character glyphs; run `fontforge -lang=py ligaturize.py --help` to list them.
 
+Pass `--license-allows-edit` if the font file is protected and you own a license that allows you to edit it.
+
 ## Misc. ##
 ### Credit ###
 This script was originally written by [IlyaSkriblovsky](https://github.com/IlyaSkriblovsky) for adding ligatures to DejaVuSans Mono ([dv-code-font](https://github.com/IlyaSkriblovsky/dv-code-font)). [Navid Rojiani](https://github.com/rojiani) made a few changes to generalize the script so that it works for any font. [ToxicFrog](https://github.com/ToxicFrog) has made a large number of contributions.

--- a/build.py
+++ b/build.py
@@ -107,7 +107,7 @@ for pattern in prefixed_fonts:
     ligaturize_font(
       input_file, ligature_font_file=None, output_dir=OUTPUT_DIR,
       prefix=LIGATURIZED_FONT_NAME_PREFIX, output_name=None,
-      copy_character_glyphs=COPY_CHARACTER_GLYPHS,
+      license_allows_edit=False, copy_character_glyphs=COPY_CHARACTER_GLYPHS,
       scale_character_glyphs_threshold=SCALE_CHARACTER_GLYPHS_THRESHOLD)
 
 for pattern,name in renamed_fonts.items():
@@ -118,6 +118,6 @@ for pattern,name in renamed_fonts.items():
   for input_file in files:
     ligaturize_font(
       input_file, ligature_font_file=None, output_dir=OUTPUT_DIR,
-      prefix=None, output_name=name,
+      prefix=None, output_name=name, license_allows_edit=False,
       copy_character_glyphs=COPY_CHARACTER_GLYPHS,
       scale_character_glyphs_threshold=SCALE_CHARACTER_GLYPHS_THRESHOLD)

--- a/ligaturize.py
+++ b/ligaturize.py
@@ -248,8 +248,9 @@ def update_font_metadata(font, new_name):
     replace_sfnt(font, 'WWS Family', new_name)
 
 def ligaturize_font(input_font_file, output_dir, ligature_font_file,
-                    output_name, prefix, **kwargs):
-    font = fontforge.open(input_font_file)
+                    output_name, prefix, license_allows_edit, **kwargs):
+    fontforge_open_flags = 1 if license_allows_edit else 0  # 1 = fstypepermitted
+    font = fontforge.open(input_font_file, fontforge_open_flags)
 
     if not ligature_font_file:
         ligature_font_file = get_ligature_source(font.fontname)
@@ -327,6 +328,10 @@ def parse_args():
     parser.add_argument("--output-name",
         type=str, default="",
         help="Name of the generated font. Completely replaces the original.")
+    parser.add_argument("--license-allows-edit",
+        default=False, action="store_true",
+        help="The user has the appropriate license to examine the font no matter"
+             "what the fstype setting is.")
     return parser.parse_args()
 
 def main():


### PR DESCRIPTION
`fontforge.open(…)` fails if the font file is protected against edits, and `fstypepermitted` is not passed explicitly.

This new parameter is optional and opt-in (_ie._ defaults to `False`) for backward compatibility/consistency, and to optain explicit acknowledgment from users that they have a valid license to edit the font.